### PR TITLE
Fix Tool configuration file dialog when selecting XRNS2XMOD Shell exe

### DIFF
--- a/control_panel_gui.lua
+++ b/control_panel_gui.lua
@@ -90,7 +90,7 @@ function show_controlpanel_dialog()
     width = 30,   
     notifier = function()
     
-      local exe_file = renoise.app():prompt_for_filename_to_read({XRNS2XMOD_EXE}, "Locate Xrns2XMod Path");
+      local exe_file = renoise.app():prompt_for_filename_to_read({XRNS2XMOD_EXE_EXTENSION}, "Locate Xrns2XMod executable: e.g. Xrns2XModShell.exe");
   
       local is_app_found = #exe_file > 0
       

--- a/globals.lua
+++ b/globals.lua
@@ -14,7 +14,7 @@
 -- the notifications.app_new_document functions or in your action callbacks...
 
 XRNS2XMOD_URL = "https://github.com/fstarred/xrns2xmod/";
-XRNS2XMOD_EXE = "Xrns2XModShell.exe";
+XRNS2XMOD_EXE_EXTENSION = "exe";
 XRNS2XMOD_DOC_URL = "https://github.com/fstarred/xrns2xmod/wiki";
 XRNS2XMOD_TUTORIAL_VIDEO_URL = "http://www.youtube.com/playlist?list=PLZZHTXBWLnp8L60rT10UOZCqe0m5J9Uyr";
 XRNS2XMOD_VERSION_INFO_URL = 'http://starredmediasoft.com/xrns2xmod_updater.xml'


### PR DESCRIPTION
- Use file extension instead of full filename to configure dialog
- Seen on MacOS 10.13.6 / Renoise 3.1.1 64b
- Affirmed by Renoise API documentation http://files.renoise.com/xrnx/documentation/Renoise.Application.API.lua.html
```
Opens a modal dialog to query a filename and path to read from a file. The given extension(s) should be something like {"wav", "aiff" or "*" (any file) }

renoise.app():prompt_for_filename_to_read({file_extensions}, dialog_title)
  -> [filename or empty string]
```
- Make more explicit the configuration file dialog's textual
  instructions

![image](https://user-images.githubusercontent.com/704698/45377938-1713e080-b5ca-11e8-9870-f0b0710335c5.png)
